### PR TITLE
Change typehints to use Consumer and Producer

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject net.tbt-post/clj-kafka-x "0.4.0"
+(defproject net.tbt-post/clj-kafka-x "0.4.1"
   :description "A Clojure wrapper for Apache Kafka v2 client"
   :url "https://github.com/source-c/clj-kafka-x"
   :license {:name "Apache License 2.0"

--- a/src/clj_kafka_x/producer.clj
+++ b/src/clj_kafka_x/producer.clj
@@ -5,7 +5,7 @@
   (:refer-clojure :exclude [send flush])
   (:require [clj-kafka-x.data :refer :all])
   (:import [java.util.concurrent Future TimeUnit TimeoutException]
-           [org.apache.kafka.clients.producer Callback KafkaProducer ProducerRecord RecordMetadata]
+           [org.apache.kafka.clients.producer Callback Producer KafkaProducer ProducerRecord RecordMetadata]
            [org.apache.kafka.common Metric MetricName]
            (org.apache.kafka.common.serialization Serializer ByteArraySerializer StringSerializer)
            (java.util Map)))
@@ -95,10 +95,10 @@
   ;; => #object[string representation of future object]
   ;; Metadata-> {:topic topic-unknown, :partition 4, :offset 1} Exception-> nil
   "
-  ([^KafkaProducer producer record]
+  ([^Producer producer record]
    (let [fut (.send producer record)]
      (map-future-val fut to-clojure)))
-  ([^KafkaProducer producer record callback]
+  ([^Producer producer record callback]
    (let [fut (.send producer record (reify Callback
                                       (onCompletion [_ metadata exception]
                                         (callback (and metadata (to-clojure metadata)) exception))))]
@@ -106,7 +106,7 @@
 
 (defn flush
   "See: http://kafka.apache.org/0100/javadoc/org/apache/kafka/clients/producer/KafkaProducer.html#flush()"
-  [^KafkaProducer producer]
+  [^Producer producer]
   (.flush producer))
 
 (defn close
@@ -116,9 +116,9 @@
 
   - http://kafka.apache.org/0100/javadoc/org/apache/kafka/clients/producer/KafkaProducer.html#close()
   - http://kafka.apache.org/0100/javadoc/org/apache/kafka/clients/producer/KafkaProducer.html#close(long,%20java.util.concurrent.TimeUnit)"
-  ([^KafkaProducer producer]
+  ([^Producer producer]
    (.close producer))
-  ([^KafkaProducer producer timeout-ms]
+  ([^Producer producer timeout-ms]
    (.close producer timeout-ms TimeUnit/MILLISECONDS)))
 
 (defn partitions
@@ -143,7 +143,7 @@
   ;;      :in-sync-replicas [{:id 1, :host \"172.17.0.4\", :port 9092}
   ;;                         {:id 2, :host \"172.17.0.3\", :port 9093}]}]
   "
-  [^KafkaProducer producer topic]
+  [^Producer producer topic]
   (mapv to-clojure (.partitionsFor producer topic)))
 
 (defn metrics
@@ -170,6 +170,6 @@
   ;;      :tags {\"client-id\" \"producer-2\", \"node-id\" \"node-3\"},
   ;;      :value 0.23866348448687352}]
   "
-  [^KafkaProducer producer]
+  [^Producer producer]
   (metrics->map (.metrics producer))
   )


### PR DESCRIPTION
Fixes #1 

PR bumps the version number to 0.4.1.

Previously typehints in namespaces `clj-kafka-x.consumers.simple` and `clj-kafka-x.producer` used implementation classes `KafkaConsumer` and `KafkaProducer`. This causes a problem when trying to test application code with fake/mock implementations of those classes. If passing anything else to those functions using the typehints one gets a `ClassCastException`. One could use Clojure's `proxy` or similar mechanisms to try to get around this problem but unfortunately the inner implementation of especially `KafkaProducer` makes mocking them via this manner practically impossible (there are some very nasty ways like JavaAssist but those should be unnecessary).

Because of this very reason in Kafka Client library there are interfaces `Consumer` and `Producer` which `KafkaConsumer` and `KafkaProducer` implements.

This commit replaces all typehint references to use those two interfaces to allow clean fake/mock implementation usage in tests. This is a non-breaking change and doesn't affect execution or performance characteristics of code in any way when using real `KafkaProducer` or `KafkaConsumer`. Typehint safety is also retained since code is referring to very same public methods as before.

After this developers are free to use whatever methods they find necessary to provide mock/fake implementations. They can use ready made `MockConsumer` and `MockProducer` or write their own for example with `proxy` or `reify`.